### PR TITLE
singleflight: remove dead doneInitialized block in doCall

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -102,9 +102,6 @@ func (g *Group[K, A, V]) doCall(ctx context.Context, key K, arg A, c *call[V], f
 			if g.m[key] == c {
 				delete(g.m, key)
 			}
-			if !c.doneInitialized {
-				c.doneInitialized = true
-			}
 			g.mu.Unlock()
 			if c.done != nil {
 				close(c.done)


### PR DESCRIPTION
## Summary

Removes the dead block `if !c.doneInitialized { c.doneInitialized = true }` from `doCall` (`singleflight/singleflight.go`).

## Why it is dead code

In `doCall` the cleanup callback holds `g.mu` and:

1. Deletes the key from `g.m` (when `g.m[key] == c`) — so after this critical section, no future `getOrCreateCall` can find this `*call` via `g.m[key]` and read its `doneInitialized` flag. The flag is only ever read by `getOrCreateCall` under `g.mu`, in the branch where `g.m[key] == c`.
2. The close decision below uses `c.done != nil`, not the flag.

So the write is never observed. The call is also zeroed (`*c = call[V]{}`) before being returned to the pool, so the write does not persist.

The `doneInitialized` field is kept: it is still used by `getOrCreateCall` to lazily create the `done` channel for waiting callers.

## Validation

- `go test -coverprofile=cover.out ./...` — all pass, `singleflight` package at **100.0%** coverage (`doCall` 100%).
- `make all` (build, test, lint, mod-tidy) — 0 lint issues.