### PR TITLE
singleflight: remove unreachable nil-channel fall-through in waitCall

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -78,12 +78,10 @@ func (g *Group[K, A, V]) waitCall(ctx context.Context, key K, c *call[V]) (v V, 
 	if g.OnWait != nil {
 		g.OnWait(ctx, key)
 	}
-	if c.done != nil {
-		select {
-		case <-c.done:
-		case <-ctx.Done():
-			return v, context.Cause(ctx) //nolint:wrapcheck // Not needed.
-		}
+	select {
+	case <-c.done:
+	case <-ctx.Done():
+		return v, context.Cause(ctx) //nolint:wrapcheck // Not needed.
 	}
 	c.checkGoexit()
 	c.checkPanic()


### PR DESCRIPTION
## Summary

Removes the `if c.done != nil` guard around the `select` in `waitCall` (`singleflight/singleflight.go`), and the nil-channel fall-through (skip the `select`) it implied.

## Why it is dead code

`waitCall` is only reached by waiting callers (`exists == true` in `getOrCreateCall`). For a waiter to find the call in `g.m`, it must acquire `g.mu` *before* the doer's cleanup callback deletes the key. The doer deletes the key and writes `c.doneInitialized` in the same critical section, so:

- If the waiter is the first to arrive, `c.doneInitialized` is still `false` and it creates `c.done`.
- If `c.doneInitialized` is already `true`, it was set by a previous waiter, who also created `c.done`.

The doer setting `c.doneInitialized = true` *without* creating `c.done` happens only inside the critical section that first deletes the key — so no waiter that still finds the key can observe that state. A waiter that arrives after the key is deleted never finds the call and becomes a new doer instead.

Therefore `c.done` is always non-nil when `waitCall` runs, the guard is always true, and the nil fall-through is unreachable.

## Validation

- `go test -coverprofile=cover.out ./...` — all pass, `singleflight` package at **100.0%** coverage (`waitCall` 100%).
- `make all` (build, test, lint, mod-tidy) — 0 lint issues.